### PR TITLE
Remove jupyterlab from requirements

### DIFF
--- a/changelog/17.bugfix.rst
+++ b/changelog/17.bugfix.rst
@@ -1,0 +1,1 @@
+Remove jupyterlab as requirement

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,6 @@ packages =
     find:
 include_package_data = True
 install_requires =
-    jupyterlab>=4.2.5,<5
     pandas>=2.2,<3
     pydantic>=2.6.3,<3
 


### PR DESCRIPTION
# Overview
Closes #17 -- remove jupyterlab as it is not an explicit code requirement and pulls in nbconvert (currently with an open a CVE)

## Description of changes
Remove the explicit dependency of jupyter lab.  It's mostly avoidance since the example notebooks do expect jupyter to run... but allows users freedom to satisfy it (NOT a code requirement) in their environments and avoid the vulnerability.


## Author Checklist
- [ ] Linting passes; run early with [pre-commit hook](https://pre-commit.com/#install).
- [ ] Tests added for new code and issue being fixed.
- [ ] Added type annotations and full numpy-style docstrings for new methods.
- [ ] Draft your news fragment in new `changelog/ISSUE.TYPE.rst` files; see [changelog/README.md](https://github.com/epic-open-source/evaluation-instruments/blob/main/changelog/README.md).
